### PR TITLE
requirements.txt: Remove math

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ scikit-allel>=1.2
 numpy
 pandas
 scipy
-math
 h5py
 zarr


### PR DESCRIPTION
Math is part of the Python standard library. It works out of the box on Python 2.7:

    $ python2
    Python 2.7.18 (default, Apr 23 2020, 22:32:06)
    [GCC 9.3.0] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from math import sqrt, pi
    >>>

... and Python 3.8:

    $ python3
    Python 3.8.2 (default, Apr  8 2020, 14:31:25)
    [GCC 9.3.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> from math import sqrt, pi
    >>>

Furthermore, this being in `requirements.txt` actually makes pip exit with an error.