### PR TITLE
fix a bug of path 

### DIFF
--- a/bin/xpclr
+++ b/bin/xpclr
@@ -81,7 +81,7 @@ def main():
 
     logging.basicConfig(format=LOGFORMAT, level=args.verbose, datefmt="%Y-%m-%d %H:%M:%S")
 
-    fn = args.out
+    fn = os.path.abspath(args.out)
     outdir = os.path.dirname(fn)
 
     assert os.access(outdir, os.W_OK), \


### PR DESCRIPTION
If the paramter of outdir is not a relative path or absolute path like `--out test`, the program will cause a error of "No permission to write in the specified directory". 
To avoid this error, we should get the the  absolute path firstly.